### PR TITLE
Fixed error caused by empty currentTrack data

### DIFF
--- a/aural-front/app/components/WebPlayback.tsx
+++ b/aural-front/app/components/WebPlayback.tsx
@@ -302,15 +302,15 @@ const WebPlayback: React.FC<Props> = ({ token }) => {
                 <TouchableOpacity onPress={openReproductionModal} style={styles.layout}>
                     <View style={styles.mainWrapper}>
                         <View style={styles.innerBar}>
-                            {currentTrack.album.images[0].url !== '' && (
+                            {currentTrack?.album?.images[0]?.url !== '' && (
                                 <Image
-                                    source={{ uri: currentTrack.album.images[0].url }}
+                                    source={{ uri: currentTrack?.album?.images[0]?.url }}
                                     style={styles.cover}
                                 />
                             )}
                             <View style={styles.info}>
-                                <Text style={styles.trackName}>{currentTrack.name ? currentTrack.name : 'No music playing'}</Text>
-                                <Text style={styles.artistName}>{currentTrack.artists[0].name ? currentTrack.artists[0].name : ''}</Text>
+                                <Text style={styles.trackName}>{currentTrack?.name ? currentTrack?.name : 'No music playing'}</Text>
+                                <Text style={styles.artistName}>{currentTrack?.artists[0]?.name ? currentTrack?.artists[0]?.name : ''}</Text>
                             </View>
                         </View>
                         <View style={styles.controls}>


### PR DESCRIPTION
S'ha corregit l'error produït en intentar llegir les dades de currentTrack quan, puntualment, el retorn de l'API era en blanc o null. S'ha aplicat el canvi també en altres parts posteriors del codi per a evitar que passi en el futur.